### PR TITLE
Resolve Launch problems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,19 +17,19 @@ env:
   # Build a release build
   BUILD_TYPE: Release
   # MSVC installation directory
-  VCINSTALLDIR: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/
+  VCINSTALLDIR: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/
 
 jobs:
   windows:
     timeout-minutes: 15
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -G "Visual Studio 16 2019"
+      run: cmake -B ${{github.workspace}}/build -G "Visual Studio 17 2022"
 
     - name: Compile
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 
 set(VER_MAJOR 1)
 set(VER_MINOR 0)
 set(VER_PATCH 0)
-set(VER_BUILD 3)
+set(VER_BUILD 4)
 set(APP_VERSION "${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.${VER_BUILD}")
 
 set(COMPANY_NAME "Pharos Labs")

--- a/src/DesignerVersionChooser.cpp
+++ b/src/DesignerVersionChooser.cpp
@@ -123,6 +123,18 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
    return TRUE;
 }
 
+bool LaunchProcess(const std::wstring& path, const std::wstring& args = std::wstring())
+{
+    STARTUPINFO info = { sizeof(info) };
+    PROCESS_INFORMATION processInfo;
+    auto cmdline = path + std::wstring(L" ") + args;
+    auto ok = CreateProcess(NULL, cmdline.data(), NULL, NULL, TRUE, 0, NULL, NULL, &info, &processInfo);
+    CloseHandle(processInfo.hProcess);
+    CloseHandle(processInfo.hThread);
+    return ok;
+}
+
+
 VOID LaunchDesigner(const bool debugMode)
 {
     const auto selItem = static_cast<INT>(SendMessage(hwList, LB_GETCURSEL, 0, 0));
@@ -136,7 +148,7 @@ VOID LaunchDesigner(const bool debugMode)
             commandLine += std::wstring(L"-d ");
         }
         commandLine.append(szCommandLine);
-        ShellExecute(NULL, NULL, path.c_str(), commandLine.data(), directory.c_str(), SW_NORMAL);
+        LaunchProcess(path, commandLine);
     }
 }
 
@@ -146,6 +158,7 @@ VOID LaunchRecoveryTool()
     if ((selItem >= 0) && (mList.size() > selItem))
     {
         const auto path = mList.at(selItem).recoveryToolPath();
+        // Use ShellExecute here as recovery tool needs privilege escalation
         ShellExecute(NULL, NULL, path.c_str(), NULL, NULL, SW_SHOWNORMAL);
     }
 }
@@ -154,7 +167,7 @@ VOID UninstallDesigner()
 {
     int selItem = (INT)SendMessage(hwList, LB_GETCURSEL, 0, 0);
     std::wstring path = mList.at(selItem).uninstallerPath();
-    ShellExecute(NULL, NULL, path.c_str(), NULL, NULL, SW_NORMAL);
+    LaunchProcess(path);
 }
 
 


### PR DESCRIPTION
There have been periodic problems reported launching Designer, with the app not fully launching or running in the background.

It appears that switching away from `ShellExecute` to `CreateProcess` resolves that. Unclear why, but this makes that change.